### PR TITLE
fix(slack): DM fallback, avatar picker, terms on focus, drop Context

### DIFF
--- a/src/app/api/slack/commands/route.ts
+++ b/src/app/api/slack/commands/route.ts
@@ -68,10 +68,9 @@ function buildChargeModal(input: {
         block_id: "charged_user",
         label: { type: "plain_text", text: "Who said it?" },
         element: {
-          type: "external_select",
+          type: "users_select",
           action_id: "value",
-          placeholder: { type: "plain_text", text: "Search teammates" },
-          min_query_length: 0,
+          placeholder: { type: "plain_text", text: "Select a teammate" },
         },
       },
       {
@@ -81,20 +80,8 @@ function buildChargeModal(input: {
         element: {
           type: "external_select",
           action_id: "value",
-          placeholder: { type: "plain_text", text: "Type to search or add a new term" },
-          min_query_length: 1,
-        },
-      },
-      {
-        type: "input",
-        block_id: "message",
-        optional: true,
-        label: { type: "plain_text", text: "Context" },
-        element: {
-          type: "plain_text_input",
-          action_id: "value",
-          multiline: true,
-          placeholder: { type: "plain_text", text: "What did they say?" },
+          placeholder: { type: "plain_text", text: "Search or add a new term" },
+          min_query_length: 0,
         },
       },
     ],

--- a/src/app/api/slack/interactions/route.ts
+++ b/src/app/api/slack/interactions/route.ts
@@ -69,9 +69,8 @@ async function handleChargeSubmission(payload: SlackInteractionPayload, origin: 
   }
   const values = payload.view?.state?.values ?? {}
 
-  const chargedSlackUserId = values.charged_user?.value?.selected_option?.value
+  const chargedSlackUserId = values.charged_user?.value?.selected_user
   const selectedTermValue = values.jargon_term?.value?.selected_option?.value
-  const messageText = values.message?.value?.value?.trim() ?? ""
 
   const errors: Record<string, string> = {}
   if (!chargedSlackUserId) errors.charged_user = "Pick a teammate to charge."
@@ -92,9 +91,26 @@ async function handleChargeSubmission(payload: SlackInteractionPayload, origin: 
   const slack = new WebClient(workspace.installation.botToken)
   const chargingSlackUserId = metadata.charging_slack_user_id ?? payload.user.id
 
+  const chargedProfile = await fetchSlackUserInfo(
+    workspace.installation.botToken,
+    chargedSlackUserId!
+  )
+  if (chargedProfile.isBot || chargedProfile.isDeleted) {
+    return NextResponse.json({
+      response_action: "errors",
+      errors: { charged_user: "You can only charge humans. Pick a teammate." },
+    })
+  }
+
   const [chargingMember, chargedMember] = await Promise.all([
     ensureMember(workspace.id, workspace.installation.botToken, chargingSlackUserId),
-    ensureMember(workspace.id, workspace.installation.botToken, chargedSlackUserId!),
+    upsertWorkspaceMember({
+      workspaceId: workspace.id,
+      slackUserId: chargedProfile.slackUserId,
+      email: chargedProfile.email,
+      displayName: chargedProfile.displayName,
+      avatarUrl: chargedProfile.avatarUrl,
+    }),
   ])
 
   let termId: string
@@ -142,7 +158,7 @@ async function handleChargeSubmission(payload: SlackInteractionPayload, origin: 
     chargingMemberId: chargingMember.id,
     jargonTermId: termId,
     amount,
-    messageText,
+    messageText: "",
     messageTs: metadata.thread_ts ?? null,
     channelId: metadata.channel_id ?? "",
   })
@@ -156,8 +172,9 @@ async function handleChargeSubmission(payload: SlackInteractionPayload, origin: 
 
   const notification = await postChargeNotificationWithFallback({
     postMessage: slack.chat.postMessage.bind(slack.chat),
-    postEphemeral: slack.chat.postEphemeral.bind(slack.chat),
+    openConversation: slack.conversations.open.bind(slack.conversations),
     channelId: metadata.channel_id!,
+    channelDisplayId: metadata.channel_id!,
     threadTs: metadata.thread_ts,
     chargingSlackUserId,
     chargedSlackUserId: chargedSlackUserId!,
@@ -167,13 +184,12 @@ async function handleChargeSubmission(payload: SlackInteractionPayload, origin: 
     leaderboardUrl: `${baseUrl}/dashboard/leaderboard`,
     receiptUrl: `${baseUrl}/receipt/${charge.id}`,
     receiptImageUrl: `${baseUrl}/receipt/${charge.id}/opengraph-image`,
-    context: messageText,
   })
 
   if (!notification.ok) {
     console.error("Slack charge notification failed entirely:", notification.error)
-  } else if (notification.fallback === "ephemeral") {
-    console.warn("Slack charge fell back to ephemeral:", notification.reason)
+  } else if (notification.fallback === "dm") {
+    console.warn("Slack charge fell back to DM:", notification.reason)
   } else {
     const confirmation = await postChargeConfirmation({
       postEphemeral: slack.chat.postEphemeral.bind(slack.chat),

--- a/src/lib/slack/api.ts
+++ b/src/lib/slack/api.ts
@@ -31,6 +31,9 @@ type SlackUserInfoResponse = {
     id: string
     name?: string
     real_name?: string
+    deleted?: boolean
+    is_bot?: boolean
+    is_app_user?: boolean
     profile?: {
       email?: string
       display_name?: string
@@ -112,6 +115,8 @@ export async function fetchSlackUserInfo(botToken: string, userId: string) {
       data.user.name ||
       "Unknown User",
     avatarUrl: profile?.image_512 || profile?.image_192 || profile?.image_72 || null,
+    isBot: Boolean(data.user.is_bot || data.user.is_app_user),
+    isDeleted: Boolean(data.user.deleted),
   }
 }
 

--- a/src/lib/slack/notifications.test.ts
+++ b/src/lib/slack/notifications.test.ts
@@ -138,51 +138,18 @@ describe("Slack notifications", () => {
     expect(imageBlock.alt_text).toContain("circle back")
   })
 
-  it("includes the context phrase as a quoted block above the image when provided", () => {
-    const blocks = buildChargeBlocks({
-      chargedSlackUserId: "U1",
-      amount: "2",
-      termName: "circle back",
-      totalOwed: "10",
-      leaderboardUrl: "https://example.com/lb",
-      receiptUrl: "https://example.com/receipt/abc",
-      receiptImageUrl: "https://example.com/receipt/abc/opengraph-image",
-      context: "let's circle back on this Q3",
-    })
-
-    expect(blocks).toHaveLength(5)
-    const quoteBlock = blocks[1] as {
-      type: "section"
-      text: { type: "mrkdwn"; text: string }
-    }
-    expect(quoteBlock.type).toBe("section")
-    expect(quoteBlock.text.text).toContain("circle back on this Q3")
-    expect(quoteBlock.text.text.startsWith("> ")).toBe(true)
-    expect(blocks[2].type).toBe("image")
-  })
-
-  it("omits the context block when context is empty or whitespace", () => {
-    const blocks = buildChargeBlocks({
-      chargedSlackUserId: "U1",
-      amount: "2",
-      termName: "circle back",
-      totalOwed: "10",
-      leaderboardUrl: "https://example.com/lb",
-      receiptUrl: "https://example.com/receipt/abc",
-      receiptImageUrl: "https://example.com/receipt/abc/opengraph-image",
-      context: "   ",
-    })
-    expect(blocks).toHaveLength(4)
-  })
-
-  it("falls back to an ephemeral charger message when the channel post fails with not_in_channel", async () => {
-    const postMessage = vi.fn().mockRejectedValue(new Error("not_in_channel"))
-    const postEphemeral = vi.fn().mockResolvedValue({ ok: true })
+  it("falls back to a DM when the channel post fails with not_in_channel", async () => {
+    const postMessage = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("not_in_channel"))
+      .mockResolvedValueOnce({ ok: true })
+    const openConversation = vi.fn().mockResolvedValue({ ok: true, channel: { id: "D999" } })
 
     const result = await postChargeNotificationWithFallback({
       postMessage,
-      postEphemeral,
+      openConversation,
       channelId: "C123",
+      channelDisplayId: "C123",
       threadTs: null,
       chargingSlackUserId: "U999",
       chargedSlackUserId: "U123",
@@ -194,24 +161,30 @@ describe("Slack notifications", () => {
       receiptImageUrl: "https://x/r/abc/opengraph-image",
     })
 
-    expect(result).toEqual({ ok: true, fallback: "ephemeral", reason: "not_in_channel" })
-    expect(postEphemeral).toHaveBeenCalledWith(
+    expect(result).toEqual({ ok: true, fallback: "dm", reason: "not_in_channel" })
+    expect(openConversation).toHaveBeenCalledWith({ users: "U999" })
+    expect(postMessage).toHaveBeenCalledTimes(2)
+    expect(postMessage.mock.calls[1][0]).toEqual(
       expect.objectContaining({
-        channel: "C123",
-        user: "U999",
+        channel: "D999",
         text: expect.stringContaining("/invite @JargonJar"),
       })
     )
+    expect(postMessage.mock.calls[1][0].text).toContain("<#C123>")
   })
 
-  it("falls back to an ephemeral with a generic reason for other channel-post errors", async () => {
-    const postMessage = vi.fn().mockRejectedValue(new Error("channel_not_found"))
-    const postEphemeral = vi.fn().mockResolvedValue({ ok: true })
+  it("falls back to a DM with a generic reason for other channel-post errors", async () => {
+    const postMessage = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("channel_not_found"))
+      .mockResolvedValueOnce({ ok: true })
+    const openConversation = vi.fn().mockResolvedValue({ ok: true, channel: { id: "D999" } })
 
     const result = await postChargeNotificationWithFallback({
       postMessage,
-      postEphemeral,
+      openConversation,
       channelId: "C123",
+      channelDisplayId: "C123",
       threadTs: null,
       chargingSlackUserId: "U999",
       chargedSlackUserId: "U123",
@@ -223,22 +196,45 @@ describe("Slack notifications", () => {
       receiptImageUrl: "https://x/r/abc/opengraph-image",
     })
 
-    expect(result).toEqual({ ok: true, fallback: "ephemeral", reason: "channel_not_found" })
-    expect(postEphemeral).toHaveBeenCalledWith(
-      expect.objectContaining({
-        text: expect.stringContaining("channel_not_found"),
-      })
-    )
+    expect(result).toEqual({ ok: true, fallback: "dm", reason: "channel_not_found" })
+    expect(postMessage.mock.calls[1][0].text).toContain("channel_not_found")
+  })
+
+  it("returns an error when both the channel post and the DM fallback fail", async () => {
+    const postMessage = vi.fn().mockRejectedValue(new Error("not_in_channel"))
+    const openConversation = vi.fn().mockResolvedValue({ ok: false, error: "user_not_found" })
+
+    const result = await postChargeNotificationWithFallback({
+      postMessage,
+      openConversation,
+      channelId: "C123",
+      channelDisplayId: "C123",
+      threadTs: null,
+      chargingSlackUserId: "U999",
+      chargedSlackUserId: "U123",
+      amount: "1",
+      termName: "synergy",
+      totalOwed: "1",
+      leaderboardUrl: "https://x/lb",
+      receiptUrl: "https://x/r/abc",
+      receiptImageUrl: "https://x/r/abc/opengraph-image",
+    })
+
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.error).toContain("user_not_found")
+    }
   })
 
   it("returns ok+null fallback when the primary channel post succeeds", async () => {
     const postMessage = vi.fn().mockResolvedValue({ ok: true })
-    const postEphemeral = vi.fn()
+    const openConversation = vi.fn()
 
     const result = await postChargeNotificationWithFallback({
       postMessage,
-      postEphemeral,
+      openConversation,
       channelId: "C123",
+      channelDisplayId: "C123",
       threadTs: null,
       chargingSlackUserId: "U999",
       chargedSlackUserId: "U123",
@@ -251,6 +247,6 @@ describe("Slack notifications", () => {
     })
 
     expect(result).toEqual({ ok: true, fallback: null })
-    expect(postEphemeral).not.toHaveBeenCalled()
+    expect(openConversation).not.toHaveBeenCalled()
   })
 })

--- a/src/lib/slack/notifications.ts
+++ b/src/lib/slack/notifications.ts
@@ -25,7 +25,6 @@ type ChargeNotificationInput = {
   leaderboardUrl: string
   receiptUrl: string
   receiptImageUrl: string
-  context?: string | null
 }
 
 type ChargeConfirmationInput = {
@@ -52,11 +51,9 @@ export function buildChargeBlocks(input: {
   leaderboardUrl: string
   receiptUrl: string
   receiptImageUrl: string
-  context?: string | null
 }): KnownBlock[] {
   const fine = formatMoney(input.amount)
   const total = formatMoney(input.totalOwed)
-  const contextText = input.context?.trim() ?? ""
 
   return [
     {
@@ -66,17 +63,6 @@ export function buildChargeBlocks(input: {
         text: `:dollar: *<@${input.chargedSlackUserId}>* was charged *$${fine}* for *"${input.termName}"*.`,
       },
     },
-    ...(contextText.length > 0
-      ? [
-          {
-            type: "section" as const,
-            text: {
-              type: "mrkdwn" as const,
-              text: `> ${contextText.replace(/\n/g, "\n> ")}`,
-            },
-          },
-        ]
-      : []),
     {
       type: "image",
       image_url: input.receiptImageUrl,
@@ -123,7 +109,6 @@ export async function postChargeNotification({
   leaderboardUrl,
   receiptUrl,
   receiptImageUrl,
-  context,
 }: ChargeNotificationInput): Promise<NotificationResult> {
   try {
     await postMessage({
@@ -138,7 +123,6 @@ export async function postChargeNotification({
         leaderboardUrl,
         receiptUrl,
         receiptImageUrl,
-        context,
       }),
     })
 
@@ -151,14 +135,19 @@ export async function postChargeNotification({
   }
 }
 
+type OpenConversation = (input: {
+  users: string
+}) => Promise<{ ok?: boolean; channel?: { id?: string }; error?: string }>
+
 type ChargeNotificationWithFallbackInput = ChargeNotificationInput & {
-  postEphemeral: PostEphemeral
+  openConversation: OpenConversation
   chargingSlackUserId: string
+  channelDisplayId: string
 }
 
 type FallbackResult =
   | { ok: true; fallback: null }
-  | { ok: true; fallback: "ephemeral"; reason: string }
+  | { ok: true; fallback: "dm"; reason: string }
   | { ok: false; error: string }
 
 export async function postChargeNotificationWithFallback(
@@ -169,19 +158,25 @@ export async function postChargeNotificationWithFallback(
 
   const reason = primary.error
   const fine = formatMoney(input.amount)
-  const ephemeralText =
+  const channelRef = input.channelDisplayId
+    ? `<#${input.channelDisplayId}>`
+    : "that channel"
+  const dmText =
     reason === "not_in_channel"
-      ? `:warning: I couldn't post the receipt in this channel. Invite me with \`/invite @JargonJar\` and try again. Your charge of $${fine} for "${input.termName}" was saved: ${input.receiptUrl}`
-      : `:warning: Couldn't post the receipt to the channel (\`${reason}\`). Your charge of $${fine} for "${input.termName}" was saved: ${input.receiptUrl}`
+      ? `:warning: I couldn't post the receipt in ${channelRef} because I'm not a member there. Invite me with \`/invite @JargonJar\` and the next charge will land in-channel. Charge of *$${fine}* for *"${input.termName}"* was still saved: ${input.receiptUrl}`
+      : `:warning: Couldn't post the receipt to ${channelRef} (\`${reason}\`). Charge of *$${fine}* for *"${input.termName}"* was still saved: ${input.receiptUrl}`
 
   try {
-    await input.postEphemeral({
-      channel: input.channelId,
-      user: input.chargingSlackUserId,
-      thread_ts: input.threadTs ?? undefined,
-      text: ephemeralText,
+    const im = await input.openConversation({ users: input.chargingSlackUserId })
+    const dmChannel = im.channel?.id
+    if (!dmChannel) {
+      throw new Error(im.error ?? "could not open DM channel")
+    }
+    await input.postMessage({
+      channel: dmChannel,
+      text: dmText,
     })
-    return { ok: true, fallback: "ephemeral", reason }
+    return { ok: true, fallback: "dm", reason }
   } catch (error) {
     return {
       ok: false,


### PR DESCRIPTION
## What & why

Follow-ups from testing the new \`/jargon\` flow in prod:

1. **Silent failure (the real one)** — \`chat.postMessage\` AND \`chat.postEphemeral\` both require the bot to be a member of the channel. The fallback I built last round was \`postMessage\` → \`postEphemeral\` in the same channel, which failed the same way. That's why \`/jargon\` in #app-test produced nothing. Replaced with a **DM fallback via \`conversations.open\`**: when the channel post fails, we DM the charger with the warning + receipt link. Works regardless of channel membership.

2. **Teammate avatars** — Slack \`external_select\` can't render images in options at all, so we lose avatars when filtering bots via that API. Reverted to \`users_select\` (which renders avatars natively) and added submit-time validation: \`users.info\` is called on the charged user, and bots / app users / deleted accounts get an inline error. Trade-off: bots show up visually in the picker, but you can't actually charge them.

3. **Terms on focus** — Term picker now uses \`min_query_length: 0\`, so the workspace's full term list shows the moment you click it. Typing still filters; the "+ Add new term" suggestion still appears for non-matching queries.

4. **Dropped the Context field** — it was an extra step capturing input that wasn't pulling weight in the message. Removed from modal, interactions handler, notifications block builder, and tests.

## Test plan

- [ ] \`/jargon\` in a channel where bot is a member → public receipt posts inline, ephemeral confirmation also fires.
- [ ] \`/jargon\` in a channel where bot is NOT a member → DM from JargonJar to the charger with the receipt link and an "invite me with /invite @JargonJar" note.
- [ ] Teammate picker shows avatars. Picking a bot (Linear, Claude, etc.) and submitting → inline error "You can only charge humans."
- [ ] Term picker shows existing terms on focus, no typing required.
- [ ] Form has 2 fields: teammate + term. No Context, no Fine override.

🤖 Generated with [Claude Code](https://claude.com/claude-code)